### PR TITLE
Generate signature from name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ export default class Demo extends Component {
           penMinWidth={penMinWidth}
           penMaxWidth={penMaxWidth}
           style={{flex: 1, backgroundColor: 'white'}}
+          useFont={false}
           fontStyle={signatureFont}
         />
       </View>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ var content = `
 export default content;
 ```
 
+## Generating a Signature from a String
+
+If you would like to generate a signature as opposed to manually writing your own, you can enable the `useFont` prop to `true` and use the prop `name` where the generated signature will be based from.
+
+```js
+var aName = 'John Doe';
+
+<SignaturePad
+  ...
+  useFont={true}
+  name={aName}
+/>
+```
+
 ## Example
 
 ```js

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ React Native wrapper around @[szimek's](https://github.com/szimek) HTML5 Canvas 
 npm install --save react-native-signature-pad
 ```
 
+## Using a Custom Signature Font
+
+There is an option to generate a signature based off the user's name. You can use your own custom font. Currently, we recommend converting your font file into a data URL (we used [dataurl.net](http://dataurl.net/#dataurlmaker)). Store that in a .js file with the contents similar to something like below:
+
+```js
+var content = `
+  @font-face {
+    font-family: 'SignatureFont';
+    src: url(/* data url of your font */) format(/* orig font file type i.e. 'ttf' */);
+  }
+`;
+
+export default content;
+```
+
 ## Example
 
 ```js
@@ -28,6 +43,7 @@ var {
   } = React;
 
 var SignaturePad = require('react-native-signature-pad');
+var signatureFont = require('./signature-font');
 
 var penMinWidth = 2;  // Default value: 1
 var penMaxWidth = 3;  // Default value: 4
@@ -36,11 +52,14 @@ export default class Demo extends Component {
   render = () => {
     return (
       <View style={{flex: 1}}>
-          <SignaturePad onError={this._signaturePadError}
-                        onChange={this._signaturePadChange}
-                        penMinWidth={penMinWidth}
-                        penMaxWidth={penMaxWidth}
-                        style={{flex: 1, backgroundColor: 'white'}}/>
+        <SignaturePad
+          onError={this._signaturePadError}
+          onChange={this._signaturePadChange}
+          penMinWidth={penMinWidth}
+          penMaxWidth={penMaxWidth}
+          style={{flex: 1, backgroundColor: 'white'}}
+          fontStyle={signatureFont}
+        />
       </View>
     )
   };

--- a/README.md
+++ b/README.md
@@ -37,12 +37,19 @@ export default content;
 If you would like to generate a signature as opposed to manually writing your own, you can enable the `useFont` prop to `true` and use the prop `name` where the generated signature will be based from.
 
 ```js
+...
+
+var signatureFont = require('./signature-font');
+
+...
+
 var aName = 'John Doe';
 
 <SignaturePad
   ...
   useFont={true}
   name={aName}
+  fontStyle={signatureFont}
 />
 ```
 
@@ -57,7 +64,6 @@ var {
   } = React;
 
 var SignaturePad = require('react-native-signature-pad');
-var signatureFont = require('./signature-font');
 
 var penMinWidth = 2;  // Default value: 1
 var penMaxWidth = 3;  // Default value: 4
@@ -73,7 +79,6 @@ export default class Demo extends Component {
           penMaxWidth={penMaxWidth}
           style={{flex: 1, backgroundColor: 'white'}}
           useFont={false}
-          fontStyle={signatureFont}
         />
       </View>
     )

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ class SignaturePad extends Component {
         props.dataURL,
         props.penMinWidth,
         props.penMaxWidth,
+        this.state.name
       );
     var html = htmlContent(injectedJavaScript);
     this.source = { html };
@@ -52,6 +53,28 @@ class SignaturePad extends Component {
     // Given that we use url changes to communicate signature changes to the
     //  React Native app, the JS is re-injected every time a stroke is drawn.
   }
+
+  componentWillReceiveProps = (nextProps) => {
+    console.log('componentWillReceiveProps', this.state.name, nextProps.name);
+    if (this.state.name !== nextProps.name) {
+      this.setState({ name: nextProps.name });
+
+      const { backgroundColor } = StyleSheet.flatten(this.props.style);
+      var injectedJavaScript = injectedExecuteNativeFunction
+        + injectedErrorHandler
+        + injectedSignaturePad
+        + injectedApplication(
+          this.props.penColor,
+          backgroundColor,
+          this.props.dataURL,
+          this.props.penMinWidth,
+          this.props.penMaxWidth,
+          nextProps.name
+        );
+      var html = htmlContent(injectedJavaScript);
+      this.source = { html };
+    }
+  };
 
   _onNavigationChange = (args) => {
     this._parseMessageFromWebViewNavigationChange(unescape(args.url));

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ class SignaturePad extends Component {
     dataURL: PropTypes.string,
     penMinWidth: PropTypes.number,
     penMaxWidth: PropTypes.number,
+    name: PropTypes.string,
   };
 
   static defaultProps = {
@@ -32,7 +33,7 @@ class SignaturePad extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {base64DataUrl: props.dataURL || null};
+    this.state = {base64DataUrl: props.dataURL || null, name: props.name};
     const { backgroundColor } = StyleSheet.flatten(props.style);
     var injectedJavaScript = injectedExecuteNativeFunction
       + injectedErrorHandler

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ class SignaturePad extends Component {
     onChange: () => {},
     onError: () => {},
     style: {},
+    useFont: false
   };
 
   constructor(props) {

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ class SignaturePad extends Component {
     dataURL: PropTypes.string,
     penMinWidth: PropTypes.number,
     penMaxWidth: PropTypes.number,
+    useFont: PropTypes.bool,
     name: PropTypes.string,
     fontStyle: PropTypes.string,
   };
@@ -45,6 +46,7 @@ class SignaturePad extends Component {
         props.dataURL,
         props.penMinWidth,
         props.penMaxWidth,
+        props.useFont,
         this.state.name
       );
     var html = htmlContent(injectedJavaScript, props.fontStyle);
@@ -57,7 +59,7 @@ class SignaturePad extends Component {
 
   componentWillReceiveProps = (nextProps) => {
     console.log('componentWillReceiveProps', this.state.name, nextProps.name);
-    if (this.state.name !== nextProps.name) {
+    if (this.props.useFont && this.state.name !== nextProps.name) {
       this.setState({ name: nextProps.name });
 
       const { backgroundColor } = StyleSheet.flatten(this.props.style);
@@ -70,6 +72,7 @@ class SignaturePad extends Component {
           this.props.dataURL,
           this.props.penMinWidth,
           this.props.penMaxWidth,
+          this.props.useFont,
           nextProps.name
         );
       var html = htmlContent(injectedJavaScript, this.props.fontStyle);

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ class SignaturePad extends Component {
     penMinWidth: PropTypes.number,
     penMaxWidth: PropTypes.number,
     name: PropTypes.string,
+    fontStyle: PropTypes.string,
   };
 
   static defaultProps = {
@@ -46,7 +47,7 @@ class SignaturePad extends Component {
         props.penMaxWidth,
         this.state.name
       );
-    var html = htmlContent(injectedJavaScript);
+    var html = htmlContent(injectedJavaScript, props.fontStyle);
     this.source = { html };
     // We don't use WebView's injectedJavaScript because on Android,
     //  the WebView re-injects the JavaScript upon every url change.
@@ -71,7 +72,7 @@ class SignaturePad extends Component {
           this.props.penMaxWidth,
           nextProps.name
         );
-      var html = htmlContent(injectedJavaScript);
+      var html = htmlContent(injectedJavaScript, this.props.fontStyle);
       this.source = { html };
     }
   };

--- a/index.js
+++ b/index.js
@@ -59,7 +59,6 @@ class SignaturePad extends Component {
   }
 
   componentWillReceiveProps = (nextProps) => {
-    console.log('componentWillReceiveProps', this.state.name, nextProps.name);
     if (this.props.useFont && this.state.name !== nextProps.name) {
       this.setState({ name: nextProps.name });
 

--- a/injectedHtml/index.js
+++ b/injectedHtml/index.js
@@ -1,4 +1,4 @@
-var content = script =>
+var content = (script, fontStyle) =>
   `<html>
     <style>
     *
@@ -16,8 +16,12 @@ var content = script =>
       -ms-transform:rotate(-90deg)  translate(-100%, 0px);
       -webkit-transform:rotate(-90deg)  translate(-100%, 0px);*/
     }
-
     </style>
+
+    <style type="text/css">
+      ${fontStyle}
+    </style>
+
     <body>
       <canvas style="margin-left: 0; margin-top: 0;"></canvas>
       <script>

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -57,9 +57,46 @@ var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth, use
 
   if (${useFont}) {
     var context = canvasElement.getContext("2d");
+    var devicePixelRatio = 1; /* window.devicePixelRatio || 1; */
+    context.canvas.width = bodyWidth * devicePixelRatio;
+    context.canvas.height = bodyHeight * devicePixelRatio;
+
+    var ratio = Math.max(window.devicePixelRatio || 1, 1);
+    var backingStoreRatio = context.webkitBackingStorePixelRatio ||
+			context.mozBackingStorePixelRatio ||
+			context.msBackingStorePixelRatio ||
+			context.oBackingStorePixelRatio ||
+			context.backingStorePixelRatio || 1;
+    var realRatio = ratio / backingStoreRatio;
+    if (ratio !== backingStoreRatio) {
+      ratio = ratio / backingStoreRatio;
+    }
+
+    var oldWidth = context.canvas.width;
+    var oldHeight = context.canvas.height;
+
     var fontSize = 45;
-    context.font = "45px SignatureFont";
-    context.fillText('${name}', 20, 100);
+    var textHeight = 12;
+    if (realRatio === 2) {
+      fontSize = 90;
+      textHeight = 18;
+    }
+
+    var textWidth = -1;
+
+    do {
+      context.font = fontSize + "px SignatureFont";
+      textWidth = context.measureText('${name}').width * ratio;
+      fontSize = 7 * fontSize / 8;
+    } while (textWidth > oldWidth);
+
+    var textPosition = {
+      x: ((oldWidth - textWidth) / 2),
+      y: ((3 * oldHeight / 4) - textHeight)
+    };
+
+    context.fillStyle = '${penColor}';
+    context.fillText('${name}', textPosition.x, textPosition.y);
 
     /* Fire a finishedStroke function to update the state */
     executeNativeFunction('finishedStroke', {base64DataUrl: canvasElement.toDataURL()});

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -54,14 +54,15 @@ var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth, nam
   }
 
   var canvasElement = document.querySelector('canvas');
-  var context = canvasElement.getContext("2d");
 
-  var fontSize = 45;
-
-  context.font = "45px SignatureFont";
-  context.fillText('${name}', 20, 100);
-
-  /* showSignaturePad(canvasElement, 300, 300); */
+  if (${useFont}) {
+    var context = canvasElement.getContext("2d");
+    var fontSize = 45;
+    context.font = "45px SignatureFont";
+    context.fillText('${name}', 20, 100);
+  } else {
+    showSignaturePad(canvasElement, 300, 300);
+  }
 `;
 
 export default content;

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -60,6 +60,9 @@ var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth, use
     var fontSize = 45;
     context.font = "45px SignatureFont";
     context.fillText('${name}', 20, 100);
+
+    /* Fire a finishedStroke function to update the state */
+    executeNativeFunction('finishedStroke', {base64DataUrl: canvasElement.toDataURL()});
   } else {
     showSignaturePad(canvasElement, bodyWidth, bodyHeight);
   }

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -61,7 +61,7 @@ var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth, use
     context.font = "45px SignatureFont";
     context.fillText('${name}', 20, 100);
   } else {
-    showSignaturePad(canvasElement, 300, 300);
+    showSignaturePad(canvasElement, bodyWidth, bodyHeight);
   }
 `;
 

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -44,7 +44,6 @@ var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth, nam
     enableSignaturePadFunctionality();
   };
 
-
   var bodyWidth = document.body.clientWidth;
   var bodyHeight = document.body.clientHeight;
   if(!bodyWidth) {
@@ -55,7 +54,13 @@ var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth, nam
   }
 
   var canvasElement = document.querySelector('canvas');
-  showSignaturePad(canvasElement, bodyWidth, bodyHeight);
+  var context = canvasElement.getContext("2d");
+
+  var fontSize = 45;
+
+  context.font = "45px SignatureFont";
+  context.fillText('${name}', 20, 100);
+
   /* showSignaturePad(canvasElement, 300, 300); */
 `;
 

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -56,6 +56,7 @@ var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth) => 
 
   var canvasElement = document.querySelector('canvas');
   showSignaturePad(canvasElement, bodyWidth, bodyHeight);
+  /* showSignaturePad(canvasElement, 300, 300); */
 `;
 
 export default content;

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -1,4 +1,4 @@
-var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth, name) => `
+var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth, useFont, name) => `
 
   var showSignaturePad = function (signaturePadCanvas, bodyWidth, bodyHeight) {
     /*We're rotating by 90% -> Flip X and Y*/

--- a/injectedJavaScript/application.js
+++ b/injectedJavaScript/application.js
@@ -1,4 +1,4 @@
-var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth) => `
+var content = (penColor, backgroundColor, dataURL, penMinWidth, penMaxWidth, name) => `
 
   var showSignaturePad = function (signaturePadCanvas, bodyWidth, bodyHeight) {
     /*We're rotating by 90% -> Flip X and Y*/


### PR DESCRIPTION
Add the feature of generating a signature from a string (generally a name).

The `useFont` prop will determine if the signature pad will generate a signature based off another prop `name`.

Along with this feature, users can add a custom font file to use as the signature font.